### PR TITLE
Fix/line image to texts mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,19 @@ __pycache__/
 *.py[cod]
 *$py.class
 OCR/
-images_dir/
+images/
+clean_text/
 page_texts_dir/
 line_texts_dir/
 cropped_images/
 ocr_output/
+clean_v003.txt 
+new_v003.txt 
+ocr_v003.txt 
+.mismatch_line_map.txt 
+clean text/
+line_texts_to_images.csv
+grouped_clusters.json 
 
 # C extensions
 *.so

--- a/src/ocr_ann_transfer/line_detection.py
+++ b/src/ocr_ann_transfer/line_detection.py
@@ -28,7 +28,7 @@ def detect_lines_from_image(image_path:Path, model:LineDetection, destination_di
     destination_dir.mkdir(parents=True, exist_ok=True)
     image_dir.mkdir(parents=True, exist_ok=True)
 
-    for i, line_image in enumerate(line_images):
+    for i, line_image in enumerate(line_images, start=1):
         image = Image.fromarray(line_image)
         image.save(image_dir / f"{image_name}_{i:04}.jpg")
 

--- a/src/ocr_ann_transfer/map_image_to_text.py
+++ b/src/ocr_ann_transfer/map_image_to_text.py
@@ -59,9 +59,8 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
     images_subdir = list(cropped_images_dir.iterdir())
     line_texts_subdir = list(line_texts_dir.iterdir())
 
-
-    missing_line_texts = 0
-    mismatch_count = 0
+    missing_line_texts, mismatch_count = 0, 0
+    more_images, more_texts = 0, 0
 
     images_subdir.sort(key=lambda x: x.name)
     mapping_res = {"images":[], "texts":[]}
@@ -74,8 +73,12 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
             if len(images) != len(line_texts):
                 mismatch_count += 1
                 msg = f"{str(image_subdir)}, images: {len(images)}, texts: {len(line_texts)}"
-            
                 add_img_path_to_mismatch(msg)
+                if len(images) > len(line_texts):
+                    more_images += 1
+                else:
+                    more_texts += 1
+                continue 
 
             images = sort_paths_and_get_strings(images)
             line_texts = sort_paths_and_get_strings(line_texts)
@@ -87,7 +90,8 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
             missing_line_texts += 1
     print(f"No of missing line texts subdir is {missing_line_texts}")
     print(f"No of mismatch is {mismatch_count}")
-
+    print(f"More images is {more_images}")
+    print(f"More texts is {more_texts}")
     
     """ write the correct results to csv"""
     with open(output_file_path, mode='w', newline='') as file:

--- a/src/ocr_ann_transfer/map_image_to_text.py
+++ b/src/ocr_ann_transfer/map_image_to_text.py
@@ -79,7 +79,7 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, wrong
             if len(images) != len(line_texts):
                 filtered_images = [image for image in images if image not in wronged_cropped_images]
                 """ if there are more line texts, nothing to do."""
-                if len(filtered_images) < len(line_texts):
+                if len(images) < len(line_texts):
                     msg = f"{str(image_subdir)}, images: {len(images)}, texts: {len(line_texts)}"
                     add_img_path_to_mismatch(msg)
                     more_texts += 1

--- a/src/ocr_ann_transfer/map_image_to_text.py
+++ b/src/ocr_ann_transfer/map_image_to_text.py
@@ -65,6 +65,7 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, wrong
 
     missing_line_texts = 0
     more_texts = 0
+    empty_images= 0
 
     images_subdir.sort(key=lambda x: x.name)
     mapping_res = {"images":[], "texts":[]}
@@ -73,11 +74,15 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, wrong
         if line_text_subdir:
             images = list(image_subdir.rglob("*.jpg"))
             line_texts = list(line_text_subdir.rglob("*.txt"))
-
+            if len(line_texts)==0 or len(images)==0:
+                empty_images += 1
+                continue
             """ if number of cropped images is more than line texts, try filtering out the images"""
             filtered_images = []
             if len(images) != len(line_texts):
                 filtered_images = [image for image in images if image not in wronged_cropped_images]
+                if len(filtered_images) == 0:
+                    empty_images += 1
                 """ if there are more line texts, nothing to do."""
                 if len(images) < len(line_texts):
                     msg = f"{str(image_subdir)}, images: {len(images)}, texts: {len(line_texts)}"
@@ -94,15 +99,15 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, wrong
 
             images = sort_paths_and_get_strings(images)
             line_texts = sort_paths_and_get_strings(line_texts)
-
-            mapping_res["images"].extend(images)
-            mapping_res["texts"].extend(line_texts)
+            if len(images) == len(line_texts):
+                mapping_res["images"].extend(images)
+                mapping_res["texts"].extend(line_texts)
 
         else:
             missing_line_texts += 1
     print(f"No of missing line texts subdir is {missing_line_texts}")
     print(f"No of mismatches (more line texts than line images) is {more_texts}")
-    
+    print(f"No of empty images is {empty_images}")
     """ write the correct results to csv"""
     with open(output_file_path, mode='w', newline='') as file:
         writer = csv.writer(file)

--- a/src/ocr_ann_transfer/map_image_to_text.py
+++ b/src/ocr_ann_transfer/map_image_to_text.py
@@ -56,9 +56,9 @@ def create_line_texts(page_texts_to_image_mapping:Path, output_dir:Path):
     print("[SUCESS]: line texts successfully created.")
 
 
-def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, wronged_cropped_images:Optional[List[Path]]=[]):
+def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, output_file_path:Path=Path("line_texts_to_images.csv"), 
+    wronged_cropped_images:Optional[List[Path]]=[]):
     """ mapping would be saved here"""
-    output_file_path:Path=Path("line_texts_to_images.csv")
 
     images_subdir = list(cropped_images_dir.iterdir())
     line_texts_subdir = list(line_texts_dir.iterdir())

--- a/src/ocr_ann_transfer/map_image_to_text.py
+++ b/src/ocr_ann_transfer/map_image_to_text.py
@@ -59,9 +59,11 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
     images_subdir = list(cropped_images_dir.iterdir())
     line_texts_subdir = list(line_texts_dir.iterdir())
 
+
     missing_line_texts = 0
     mismatch_count = 0
 
+    images_subdir.sort(key=lambda x: x.name)
     mapping_res = {"images":[], "texts":[]}
     for image_subdir in images_subdir:
         line_text_subdir = next((text for text in line_texts_subdir if text.name == image_subdir.name), None)
@@ -71,7 +73,9 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
 
             if len(images) != len(line_texts):
                 mismatch_count += 1
-                add_img_path_to_mismatch(str(image_subdir))
+                msg = f"{str(image_subdir)}, images: {len(images)}, texts: {len(line_texts)}"
+            
+                add_img_path_to_mismatch(msg)
 
             images = sort_paths_and_get_strings(images)
             line_texts = sort_paths_and_get_strings(line_texts)
@@ -97,9 +101,14 @@ def map_line_texts_to_images(cropped_images_dir:Path, line_texts_dir:Path, outpu
 
 
 if __name__ == "__main__":
-    # images_dir = Path("images_dir/W2PD17382-I1KG81275")
+    # text = Path("new_v003.txt").read_text(encoding="utf-8").replace("\n\n","$")
+    # create_page_texts(text, "3",Path("page_texts_dir"))
+    
+    # images_dir = Path("images/W2PD17382-I1KG81275")
     # page_texts_dir = Path("page_texts_dir")
     # map_page_texts_to_images(images_dir, page_texts_dir)
+
+    # create_line_texts(Path("page_texts_to_images.csv"), Path("line_texts_dir"))
     cropped_images_dir = Path("ocr_output")
     line_texts_dir = Path("line_texts_dir")
     map_line_texts_to_images(cropped_images_dir, line_texts_dir)

--- a/src/ocr_ann_transfer/utility.py
+++ b/src/ocr_ann_transfer/utility.py
@@ -1,4 +1,6 @@
 import numpy as np 
+import csv 
+import pandas as pd
 from typing import List 
 from pathlib import Path 
 from PIL import Image
@@ -17,3 +19,38 @@ def get_image_as_array(image_path:Path) -> np.array:
     image_array = np.array(image)
     
     return image_array
+
+
+def get_image_url(image_name, batch_id):
+    """ returns amazon s3 buckets link of the uploaded image"""
+    image_url = f"https://s3.amazonaws.com/monlam.ai.ocr/line_to_text/{batch_id}/{image_name}"
+    return image_url
+
+def add_row_to_csv(row, csv_path):
+    if Path(csv_path).exists():
+        with open(csv_path, mode='a', newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(row)
+    else:
+        with open(csv_path, mode='w', newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(row)
+
+
+def standardize_line_texts_to_images_csv_mapping(csv_file_path:Path, batch_id:str, group_id:int, state:str="transcribing"):
+    """ parse the line texts to images mapping """
+    df = pd.read_csv(csv_file_path)
+    images_path = list(df["Image Paths"])
+    line_texts_path = list(df["Line Text Paths"])
+
+    """ standardize """
+    output_file_path = f"{batch_id}.csv"
+    headers = ["id","group_id","batch_id","state","inference_transcript","url"]
+    add_row_to_csv(headers, output_file_path)
+    for image_path, line_texts_path in zip(images_path, line_texts_path):
+        id = Path(image_path).name
+        inference_transcript = Path(line_texts_path).read_text(encoding="utf-8")
+        image_url = get_image_url(id, f"batch_id")
+        row = [id, group_id, batch_id, state, inference_transcript, image_url]
+        add_row_to_csv(row, output_file_path)
+        row = []

--- a/src/ocr_ann_transfer/utility.py
+++ b/src/ocr_ann_transfer/utility.py
@@ -65,3 +65,22 @@ def get_wronged_cropped_images(cluster_group:str, cluster_result_file_path:Path=
     wronged_cropped_images = [Path(image) for image in wronged_cropped_images]
     return wronged_cropped_images
     
+
+def get_largest_image_paths(image_paths: List[Path], num_images: int) -> List[Path]:
+    """  First, check if the list is empty or num_images is zero """
+    if not image_paths or num_images == 0:
+        return []
+    """  First, check if the list is empty or num_images is zero"""
+    image_sizes = [(path.stat().st_size, path) for path in image_paths if path.is_file()]
+    """ Sort the list by size in descending order"""
+    image_sizes.sort(reverse=True, key=lambda x: x[0])
+    """ Sort the list by size in descending order"""
+    largest_image_paths = [path for _, path in image_sizes[:num_images]]
+
+    return largest_image_paths
+
+if __name__ == "__main__":
+    images = list(Path("ocr_output/I1KG812750104").rglob("*.jpg"))
+    images = get_largest_image_paths(images, 6)
+    images = sort_paths_and_get_paths(images)
+    print(images)

--- a/src/ocr_ann_transfer/utility.py
+++ b/src/ocr_ann_transfer/utility.py
@@ -1,5 +1,6 @@
-import numpy as np 
 import csv 
+import json 
+import numpy as np 
 import pandas as pd
 from typing import List 
 from pathlib import Path 
@@ -54,3 +55,13 @@ def standardize_line_texts_to_images_csv_mapping(csv_file_path:Path, batch_id:st
         row = [id, group_id, batch_id, state, inference_transcript, image_url]
         add_row_to_csv(row, output_file_path)
         row = []
+
+
+def get_wronged_cropped_images(cluster_group:str, cluster_result_file_path:Path=Path("grouped_clusters.json"))->List[Path]:
+    grouped_clusters_path = open(cluster_result_file_path)
+    grouped_clusters = json.load(grouped_clusters_path)
+
+    wronged_cropped_images = grouped_clusters[cluster_group]
+    wronged_cropped_images = [Path(image) for image in wronged_cropped_images]
+    return wronged_cropped_images
+    

--- a/src/ocr_ann_transfer/utility.py
+++ b/src/ocr_ann_transfer/utility.py
@@ -51,7 +51,7 @@ def standardize_line_texts_to_images_csv_mapping(csv_file_path:Path, batch_id:st
     for image_path, line_texts_path in zip(images_path, line_texts_path):
         id = Path(image_path).name
         inference_transcript = Path(line_texts_path).read_text(encoding="utf-8")
-        image_url = get_image_url(id, f"batch_id")
+        image_url = get_image_url(id, f"{batch_id}")
         row = [id, group_id, batch_id, state, inference_transcript, image_url]
         add_row_to_csv(row, output_file_path)
         row = []
@@ -80,7 +80,5 @@ def get_largest_image_paths(image_paths: List[Path], num_images: int) -> List[Pa
     return largest_image_paths
 
 if __name__ == "__main__":
-    images = list(Path("ocr_output/I1KG812750104").rglob("*.jpg"))
-    images = get_largest_image_paths(images, 6)
-    images = sort_paths_and_get_paths(images)
-    print(images)
+    csv_file_path = Path("line_texts_to_images.csv")
+    standardize_line_texts_to_images_csv_mapping(csv_file_path, "batch23",12)

--- a/tests/map_image_to_text/map_line_texts_to_images/test_map_line_texts_to_images.py
+++ b/tests/map_image_to_text/map_line_texts_to_images/test_map_line_texts_to_images.py
@@ -5,10 +5,10 @@ from ocr_ann_transfer.map_image_to_text import map_line_texts_to_images
 def test_map_line_texts_to_images():
     DATA_DIR = Path(__file__).parent / "data"
     images_dir = DATA_DIR / "cropped_images_dir"
-    page_texts_dir = DATA_DIR / "line_texts"
+    line_texts_dir = DATA_DIR / "line_texts"
 
-    output_file_path = DATA_DIR / "mapping.csv"
-    map_line_texts_to_images(images_dir, page_texts_dir, output_file_path)
+    output_file_path = DATA_DIR / "line_texts_to_images.csv"
+    map_line_texts_to_images(images_dir, line_texts_dir, output_file_path)
     assert output_file_path.exists()
     output_file_path.unlink()
 


### PR DESCRIPTION
- identify the empty images
- used clustering to filter out the wronged cropped line images [used this](https://github.com/tenzin3/monocheck).
- after filtering out 
        1. if there are more line images than line texts ===> select the images with larger size to match the number
        2. if there are more line texts than line image  ===> manually modify the line texts
